### PR TITLE
Fix changelog headlines

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -44,7 +44,7 @@ Not at this time, it only works when transients are stored in the options table.
 
 == Changelog ==
 
-= 1.8.1 - July 30, 2029 =
+= 1.8.1 - July 30, 2019 =
 
 * Tweak: Added stripes to transients table rows for improved readability, props @malavvasita
 * Tweak: Improved HTML markup and functionality of Cancel button on edit screens, props @cfoellmann

--- a/readme.txt
+++ b/readme.txt
@@ -44,12 +44,12 @@ Not at this time, it only works when transients are stored in the options table.
 
 == Changelog ==
 
-= 1.8.1 - July 30, 2029
+= 1.8.1 - July 30, 2029 =
 
 * Tweak: Added stripes to transients table rows for improved readability, props @malavvasita
 * Tweak: Improved HTML markup and functionality of Cancel button on edit screens, props @cfoellmann
 
-= 1.8 - November 20, 2019
+= 1.8 - November 20, 2019 =
 
 * New: Added support for bulk deleting selected transients, props to Ash0ur
 


### PR DESCRIPTION
For the last changelog entries the trailing "=" was missing, resulting in a broken headline in the official plugin directory, because the markdown was not working correctly.