### PR TITLE
Added submenu to admin bar

### DIFF
--- a/transients-manager.php
+++ b/transients-manager.php
@@ -257,6 +257,14 @@ class PW_Transients_Manager {
 		);
 		$wp_admin_bar->add_node( $args );
 
+		$args = array(
+			'id'     => 'tm-view',
+			'title'  => __( 'View All Transients', 'transients-manager' ),
+			'parent' => 'tm-suspend',
+			'href'   => admin_url('tools.php?page=pw-transients-manager'),
+			'meta' => array('target' => '_blank')
+		);
+		$wp_admin_bar->add_node( $args );
 	}
 
 	/**


### PR DESCRIPTION
Added a submenu to the admin bar link to quickly and easily access the full list of transients.

Maybe in the future, quick links such as "Delete Expired Transients", "Delete Transients with an Expiration", and "Delete All Transients" could be added under an "Actions" submenu as a one-click way to easily delete transients from the front-end.