### PR TITLE
Admin: prevent PHP fatal error inside of get_transient_value_type()

### DIFF
--- a/transients-manager.php
+++ b/transients-manager.php
@@ -825,10 +825,6 @@ class AM_Transients_Manager {
 		if ( is_array( $value ) ) {
 			$type = esc_html__( 'array', 'transients-manager' );
 
-		// JSON
-		} elseif ( is_object( json_decode( $value ) ) ) {
-			$type = esc_html__( 'json', 'transients-manager' );
-
 		// Object
 		} elseif ( is_object( $value ) ) {
 			$type = esc_html__( 'object', 'transients-manager' );
@@ -859,6 +855,11 @@ class AM_Transients_Manager {
 					$type = esc_html__( 'numeric', 'transients-manager' );
 				}
 
+			// JSON
+			} elseif ( is_string( $value ) && is_object( json_decode( $value ) ) ) {
+				$type = esc_html__( 'json', 'transients-manager' );
+
+			// Scalar
 			} else {
 				$type = esc_html__( 'scalar', 'transients-manager' );
 			}


### PR DESCRIPTION
This commit lowers the priority of the "is_object( json_decode( $value ) )" check and places it inside of a "is_string()" call.

See: https://wordpress.org/support/topic/2-0-0-warning-json_decode-expects-parameter-1-to-be-string-object-given-in/

Fixes #59.