### PR TITLE
Delete All: fix MySQL LIKE prepare statement

### DIFF
--- a/transients-manager.php
+++ b/transients-manager.php
@@ -1279,10 +1279,9 @@ class AM_Transients_Manager {
 		// Query
 		$count = $wpdb->query(
 			$wpdb->prepare(
-				"DELETE FROM {$wpdb->options}
-				WHERE option_name LIKE %s"
-			),
-			$esc_name
+				"DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+				$esc_name
+			)
 		);
 
 		// Return count


### PR DESCRIPTION
This commit corrects a syntax issue with `$wpdb->prepare()` causing the unintended SQL to be generated.

Fixes #66.