### PR TITLE
Update transients-manager.php

### DIFF
--- a/transients-manager.php
+++ b/transients-manager.php
@@ -52,6 +52,30 @@ class AM_Transients_Manager {
 	public $next_cron_delete = 0;
 
 	/**
+         * ID of the transient
+	 * 
+  	 * @since 2.0.4
+    	 * @var int
+	 */
+	public $transient_id;
+
+	/**
+         * Transient object
+	 * 
+  	 * @since 2.0.4
+    	 * @var object
+	 */
+	public $transient;
+
+	/**
+         * Action name
+	 * 
+  	 * @since 2.0.4
+    	 * @var string
+	 */
+	public $action;
+
+	/**
 	 * Get things started
 	 *
 	 * @since 1.0


### PR DESCRIPTION
Adds property declarations for the $transient_id, $transient, and $action properties to avoid PHP Deprecation notices.

On PHP 8.2, I see three errors for this plugin:

```
Creation of dynamic property AM_Transients_Manager::$transient_id is deprecated
Creation of dynamic property AM_Transients_Manager::$transient is deprecated
Creation of dynamic property AM_Transients_Manager::$action is deprecated
```

The fix is simply to declare these properties in the class definition. I've set them to `public` as the other properties are, but they could probably be set to `protected` or even `private` as it doesn't look like these properties are used outside the class scope.